### PR TITLE
Debug grid face animation overlap on load

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -156,7 +156,8 @@ const gridPairs: HallOfFameMember[][] = Array.from(
       animation-duration: var(--cycle);
       animation-timing-function: linear;
       animation-iteration-count: infinite;
-      animation-delay: calc(var(--i) * var(--stagger, var(--step)));
+      /* Use negative delay so offsets persist across loops */
+      animation-delay: calc(var(--i) * var(--stagger, var(--step)) * -1);
       will-change: transform, opacity;
     }
     @keyframes gridCycle {


### PR DESCRIPTION
Fixes overlapping hero grid animation by using a negative `animation-delay`.

Positive `animation-delay` only applies at the first iteration, causing subsequent animation loops to align and overlap. Changing to a negative delay ensures the phase offset persists across all loops, including after navigation.

---
<a href="https://cursor.com/background-agent?bcId=bc-3f58d103-d4e2-4837-8dd4-83cb7079526e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3f58d103-d4e2-4837-8dd4-83cb7079526e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

