### PR TITLE
fix: hero grid face animation fitting on mobile

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -81,13 +81,13 @@ const gridPairs: HallOfFameMember[][] = Array.from(
             <!-- Center highlight slot -->
             {/*<div class="pointer-events-none absolute inset-0 rounded-xl border border-white/10"></div>*/}
             <!-- Static U-shaped grid slots -->
-            <div class="absolute inset-0 px-5 md:px-4 grid grid-cols-2 gap-4 items-end pointer-events-none z-0 content-center">
+            <div class="absolute inset-0 px-1 md:px-4 grid grid-cols-2 gap-4 items-end pointer-events-none z-0 content-center">
               <div class="h-16 sm:h-20 md:h-24 border-l-2 border-r-2 border-t-2 border-white/50 rounded-t-2xl"></div>
               <div class="h-16 sm:h-20 md:h-24 border-l-2 border-r-2 border-t-2 border-white/50 rounded-t-2xl"></div>
             </div>
             <div class="relative h-full overflow-hidden grid-stage">
               {gridPairs.map((pair, i) => (
-                <div class="pair absolute inset-0 grid grid-cols-2 gap-3 sm:gap-6 md:gap-8 items-end px-4 md:px-6 z-10 -mt-4 sm:-mt-6 md:-mt-9" style={`--i:${i}`}>
+                <div class="pair absolute inset-0 grid grid-cols-2 gap-7 sm:gap-6 md:gap-8 items-end px-2 md:px-6 z-10 -mt-4 sm:-mt-6 md:-mt-9" style={`--i:${i}`}>
                   {pair.map((p, j) => (
                     <a href={`/hall-of-fame/${p.link}`} class={`group inline-flex items-center gap-2 sm:gap-3 w-full rounded-xl border border-white/10 bg-white/10 backdrop-blur-sm px-0 py-0 transition-colors hover:border-[#9FFE88]/40 ${j === 0 ? 'justify-self-start' : 'justify-self-end'} self-center`}>
                       <img src={p.img} alt={p.nickname} class="h-9 w-9 sm:h-10 sm:w-10 rounded-l-xl object-cover ring-0 ring-white/10 group-hover:ring-[#9FFE88]/40" loading="lazy" decoding="async" />


### PR DESCRIPTION
This pull request makes minor adjustments to the grid layout in the `Hero.astro` component to improve spacing and alignment. The changes primarily involve tweaking padding and gap values for better visual balance.

* Reduced horizontal padding from `px-5` to `px-1` in the static grid container for tighter alignment.
* Increased the gap between grid pairs from `gap-3` to `gap-7` and adjusted padding from `px-4` to `px-2` for improved spacing in the dynamic grid.