### PR TITLE
refactor: remove gallery section from the index page to streamline content layout

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -44,11 +44,6 @@ const page = {
     <section id="signature-phrases" class="py-16 md:py-24">
       <SignaturePhrases />
     </section>
-
-    <!-- Gallery Section -->
-    <section id="gallery" class="py-16 md:py-24">
-      <Gallery gallery={gallery} />
-    </section>
   </div>
 
   <Footer />


### PR DESCRIPTION
This pull request makes a small change to the `src/pages/index.astro` file by removing the Gallery section from the page. The section that rendered the `Gallery` component has been deleted.