### PR TITLE
docs: configure agent skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,3 +20,17 @@
 - Reuse existing Astro components and data modules.
 - Do not refactor route or component ownership unless the task explicitly requires it.
 - Prefer typed literals with `satisfies` or explicit interfaces for data.
+
+## Agent skills
+
+### Issue tracker
+
+Issues and PRDs are tracked in GitHub Issues for `edhor1608/mxl-legacy-website`. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Triage uses the default five-label vocabulary. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+This is a single-context repo. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,28 @@
+# Domain Docs
+
+How agent skills should consume this repo's domain documentation when exploring the codebase.
+
+## Layout
+
+This is a single-context repo.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, if it exists.
+- **`docs/adr/`**, if it exists. Read ADRs that touch the area you're about to work in.
+- **`docs/ARCHITECTURE.md`** for the current Astro architecture, data flow, routes, and metadata conventions.
+- **`docs/DECISIONS.md`** for recorded project decisions.
+- **`docs/CONTENT.md`** before adding or changing historical content.
+- **`docs/TESTING.md`** before changing tests or test expectations.
+
+If `CONTEXT.md` or `docs/adr/` do not exist, proceed silently. Do not flag their absence or suggest creating them upfront. Producer skills can create them lazily when terms or decisions actually get resolved.
+
+## Use the project's vocabulary
+
+When your output names a domain concept in an issue title, refactor proposal, hypothesis, or test name, use the term as defined by the repo docs. Do not drift to synonyms the docs explicitly avoid.
+
+If the concept you need is not documented yet, either reconsider whether the project uses that language or note the gap for a documentation-focused pass.
+
+## Flag decision conflicts
+
+If your output contradicts an existing decision in `docs/DECISIONS.md` or an ADR, surface it explicitly rather than silently overriding it.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,28 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues in `edhor1608/mxl-legacy-website`. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create -R edhor1608/mxl-legacy-website --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> -R edhor1608/mxl-legacy-website --json number,title,body,labels,comments` to get structured data, or `gh issue view <number> -R edhor1608/mxl-legacy-website --comments` for readable output. The `labels` array contains label objects; use `jq` to extract label names.
+- **List issues**: Use `gh issue list` with appropriate `--label` and `--state` filters, then pipe through `jq` to shape the output:
+
+  ```sh
+  gh issue list -R edhor1608/mxl-legacy-website --state open --json number,title,body,labels,comments \
+    --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'
+  ```
+
+- **Comment on an issue**: `gh issue comment <number> -R edhor1608/mxl-legacy-website --body "..."`
+- **Apply or remove labels**: `gh issue edit <number> -R edhor1608/mxl-legacy-website --add-label "..."` / `gh issue edit <number> -R edhor1608/mxl-legacy-website --remove-label "..."`
+- **Close**: `gh issue close <number> -R edhor1608/mxl-legacy-website --comment "..."`
+
+Pass `-R edhor1608/mxl-legacy-website` in examples so forks or multiple remotes do not change the target repo. Alternatively, run `gh repo set-default edhor1608/mxl-legacy-website` once in the clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> -R edhor1608/mxl-legacy-website --json number,title,body,labels,comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in agent skills | Label in our tracker | Meaning                                  |
+| --------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`        | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`          | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`     | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`     | `ready-for-human`    | Requires human implementation            |
+| `wontfix`             | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role, use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary the repo actually uses.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add agent skills documentation for issue tracking, triage labels, and domain context
> - Adds an `Agent skills` section to [AGENTS.md](https://github.com/edhor1608/mxl-legacy-website/pull/21/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9) pointing to three new reference docs
> - [docs/agents/issue-tracker.md](https://github.com/edhor1608/mxl-legacy-website/pull/21/files#diff-ae2f28c43b72f5b82620c61d5ddc59e68e532d376d179e566977594258d46116) defines conventions for managing GitHub Issues via the `gh` CLI, including structured JSON viewing with `jq`
> - [docs/agents/triage-labels.md](https://github.com/edhor1608/mxl-legacy-website/pull/21/files#diff-f333a77f75919d67dcd863f7f28d8a324fc0e696640356ff27d936069672e806) maps five canonical triage roles (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`) to tracker label strings
> - [docs/agents/domain.md](https://github.com/edhor1608/mxl-legacy-website/pull/21/files#diff-3f6ddafc4eae369c64ec7ae1f219ba6609047b79f42ed87d34a446bead02c6bb) lists prerequisite docs agents must read and instructs them to use project vocabulary and flag conflicts with `DECISIONS.md` or ADRs
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a0e126d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added agent skills docs outlining where to find issue/PRD tracking, the default five-role triage-label vocabulary, and guidance that the repo is single-context
  * Added guidance on consuming domain docs, recommended pre-exploration reading order, and requirement to surface conflicts with existing decisions
  * Added an issue-tracker CLI guide and a triage label mapping for five canonical roles

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/edhor1608/mxl-legacy-website/pull/21?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->